### PR TITLE
Semantic versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,12 @@ envs:
 
 ** a retag is considered when using the 'remote-image' input.
 
-`semantic-versioning` - push app versions according to semantic versioning. `ecr-tag` property must contain a version or refer to one ('1.2.6', 'v1.2.6', '$$version', '$$$app-version'). | **Optional** | **Default: false**
+`semantic-versioning` - push app versions according to semantic versioning. `ecr-tag` property must contain a version or refer to one (
+'1.2.6', 
+'v1.2.6', 
+'$$version', 
+'$$$app-version'
+) | **Optional** | **Default: false**
 
 ### `ecr-tag` reserved tags ('$$$' prefix):
 

--- a/README.md
+++ b/README.md
@@ -108,5 +108,6 @@ uses: 365scores/push-to-ECR@v1
 with:
   env-key: 'qa'
   local-image: 'demo-docker-image'
-  extra-tags: 'tag-from-workflow=my-tag,app-version=${{ env.app_version }}'
+  app-version: '${{ env.app_version }}'
+  extra-tags: 'tag-from-workflow=my-tag,build-num=${{ github.run_number }}'
 ```

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ push image to configured ECR repositories with configured tags.
 
 **Optional** remote image to pull, tag & push (\<accountId\>.dkr.ecr.\<region\>.amazonaws.com/\<name\>:\<tag\>).
 
+### `app-version`
+
+**Optional** version of the pushed image, made only from numbers and dots (Examples: 1.2.6, 2.0, 2, 1.2.5.85.1).
+
 ### `extra-tags`
 
 **Optional** pass values from the workflow to be used as tags.
@@ -55,6 +59,17 @@ envs:
       ecr-tag: $$build-num
       continue-on-error: true
       only-on-build: true
+      
+    - ecr-registry: 0123456789.dkr.ecr.us-east-1.amazonaws.com
+      ecr-repository: my-repo
+      ecr-tag: $$$app-version
+      continue-on-error: true
+      
+    - ecr-registry: 0123456789.dkr.ecr.us-east-1.amazonaws.com
+      ecr-repository: other-repo
+      ecr-tag: $$$app-version
+      continue-on-error: true
+      semantic-versioning: true
 ```
 
 ### configurable properties for each ECR push target:
@@ -63,7 +78,7 @@ envs:
 
 `ecr-repository` - Name of the ECR repository (docker image name). | **Required**
 
-`ecr-tag` - Tag to be pushed to the ECR repository (docker image tag). use '$$' prefix to take the tag from the `extra-tags` input | **Required**
+`ecr-tag` - Tag to be pushed to the ECR repository (docker image tag). use '$$' prefix to take the tag from the `extra-tags` input. use '$$$' prefix to use a reserved tag type (see list below) | **Required**
 
 `force-push` - Override existing tag (even if the repo is set to use immutable tags). | **Optional** | **Default: false**
 
@@ -74,6 +89,12 @@ envs:
 `only-on-build` - push this tag only on new docker image build (not retag existing image). | **Optional** | **Default: false**
 
 ** a retag is considered when using the 'remote-image' input.
+
+`semantic-versioning` - push app versions according to semantic versioning. `ecr-tag` property must contain a version or refer to one ('1.2.6', 'v1.2.6', '$$version', '$$$app-version'). | **Optional** | **Default: false**
+
+### `ecr-tag` reserved tags ('$$$' prefix):
+
+`app-version` - takes the value from the optional `app-version` input. Can be used with `semantic-versioning` property.
 
 ## Example usage in a workflow
 

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,9 @@ inputs:
   remote-image:
     description: 'remote image (<accountId>.dkr.ecr.<region>.amazonaws.com/<name>:<tag>)'
     required: false
+  app-version:
+    description: 'version of the pushed image, made only from numbers and dots (ex. 1.2.6)'
+    required: false
   extra-tags:
     description: 'pass values from the workflow to be used as tags'
     required: false

--- a/index.js
+++ b/index.js
@@ -128,19 +128,20 @@ async function pushToECR(target) {
 		CORE.setFailed(`ECR push target has invalid value for semantic-versioning. Either omit this property or set it to one of the valid values: [true, false]`);
 		error = true;
 	}
+	if (error) { return; }
+	  
 	if (semanticVersioning) {
 		try {
 			sm_versions = calc_sm_versions(tag);
 		} catch (sm_error) {
 			CORE.setFailed(`Error in calc_sm_versions().\n${sm_error}`);
-			error = true;
+			return;
 		}
 		if (sm_versions == null || !(sm_versions.length > 0)) {
 			CORE.setFailed(`Failed to calc_sm_versions(). got 0 results based on input ${tag} and 'ecr-tag' property ${target['ecr-tag']}`);
-			error = true;
+			return;
 		}
 	}
-	if (error) { return; }
 	
 	let targetProperties = {
 	  registry,
@@ -231,7 +232,7 @@ function execAsync(command) {
 }
 
 function handleError(errorMessage, continueOnError) {
-    if (continueOnError) { console.error(errorMessage); }
+	if (continueOnError) { console.warn(errorMessage); }
 	else { CORE.setFailed(errorMessage); }
 }
 

--- a/index.js
+++ b/index.js
@@ -191,7 +191,7 @@ async function main() {
 	}
   }
   catch (error) {
-    CORE.setFailed(error.message);
+    CORE.setFailed(error);
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const YAML = require('yaml');
 const fs = require('fs');
 const { exec } = require("child_process");
 const { ECRClient, BatchDeleteImageCommand } = require("@aws-sdk/client-ecr");
+const { readReservedTag } = require("./reservedTags");
 
 // inputs
 const env_key = CORE.getInput('env-key');
@@ -35,6 +36,31 @@ function readExtraTags() {
 	return obj;
 }
 
+// calc versions for "Semantic Versioning"
+// Example: version 1.2.6 => v1.2.6, v1.2, v1
+function calc_sm_versions(version) {
+
+	const trimVPrefix_re = /^[vV]?(?<cleaned>[\d]+([\d.]*\d+)?)$/;
+	const findVersion_re = /^[\d]+[\d.]*(?=[.]\d+$)/;
+
+	var versionCleaned = version.match(trimVPrefix_re);
+	if (versionCleaned)
+		version = versionCleaned.groups.cleaned;
+	else
+		throw `malformed version: ${version}.`
+
+	let sm_versions = [];
+	sm_versions.push(`v${version}`);
+
+	while ((re_matches = findVersion_re.exec(version)) !== null) {
+		let foundVersion = re_matches[0];
+		sm_versions.push(`v${foundVersion}`);
+		version = foundVersion;
+	}
+
+	return sm_versions;
+}
+
 async function pushToECR(target) {
   try {
 	
@@ -44,6 +70,8 @@ async function pushToECR(target) {
 	const forcePush = target['force-push'];
 	const continueOnError = target['continue-on-error'];
 	const onlyOnBuild = target['only-on-build'];
+	const semanticVersioning = target['semantic-versioning'];
+	let sm_versions = null;
 	let error = false;
 	
 	if (actionTrigger !== ActionTriggersEnum.build && onlyOnBuild !== undefined && onlyOnBuild !== true && onlyOnBuild !== false) {
@@ -67,13 +95,24 @@ async function pushToECR(target) {
 		CORE.setFailed(`ECR push target is missing ecr-tag`);
 		error = true;
 	}
-	if (tag.startsWith('$$')) {
+	if (tag.startsWith('$$$')) {
+		const reserved_tag = tag.substring(3);
+		try {
+			tag = readReservedTag(reserved_tag);
+		} catch (reserved_tags_error) {
+			const errorMessage = `Failed to process reserved tag ${reserved_tag} of target ${JSON.stringify(target, null, 2)}. Error:\n${reserved_tags_error}`;
+			handleError(errorMessage, continueOnError !== false)
+			error = true;			
+		}
+	}
+	else if (tag.startsWith('$$')) {
 		const input_tag = extra_tags[tag.substring(2)];
 		if (input_tag) {
 			tag = input_tag;
 		}
 		else {
-			console.error(`warning: ECR push target is missing ecr-tag. extra-tags is missing tag ${tag.substring(2)}.`);
+			const errorMessage = `warning: ECR push target is missing ecr-tag. extra-tags is missing tag ${tag.substring(2)}.`;
+			handleError(errorMessage, continueOnError !== false)
 			error = true;
 		}
 	}
@@ -85,9 +124,54 @@ async function pushToECR(target) {
 		CORE.setFailed(`ECR push target has invalid value for continue-on-error. Either omit this property or set it to one of the valid values: [true, false]`);
 		error = true;
 	}
+	if (semanticVersioning !== undefined && semanticVersioning !== true && semanticVersioning !== false) {
+		CORE.setFailed(`ECR push target has invalid value for semantic-versioning. Either omit this property or set it to one of the valid values: [true, false]`);
+		error = true;
+	}
+	if (semanticVersioning) {
+		try {
+			sm_versions = calc_sm_versions(tag);
+		} catch (sm_error) {
+			CORE.setFailed(`Error in calc_sm_versions().\n${sm_error}`);
+			error = true;
+		}
+		if (sm_versions == null || !(sm_versions.length > 0)) {
+			CORE.setFailed(`Failed to calc_sm_versions(). got 0 results based on input ${tag} and 'ecr-tag' property ${target['ecr-tag']}`);
+			error = true;
+		}
+	}
 	if (error) { return; }
 	
-	const newImage = `'${registry}/${repository}:${tag}'`;
+	let targetProperties = {
+	  registry,
+	  repository,
+	  tag,
+	  forcePush,
+	  continueOnError
+	}
+
+	if (semanticVersioning) {
+		for (const version of sm_versions) {
+			targetProperties.tag = version;
+			await pushTag(targetProperties);
+			
+			// forcePush = true (for derived versions)
+			targetProperties = { ...targetProperties };
+			targetProperties.forcePush = true;
+		}
+		return;
+	}
+
+	await pushTag(targetProperties);
+  }
+  catch (error) {
+    CORE.setFailed(error);
+  }
+}
+
+async function pushTag(targetProps) {
+  try {
+	  const newImage = `'${targetProps.registry}/${targetProps.repository}:${targetProps.tag}'`;
 	
 	try {
 		await execAsync(`docker image tag ${local_image} ${newImage}`);
@@ -95,16 +179,15 @@ async function pushToECR(target) {
 	}
 	catch (error) {
 		const errorMessage = `tag ${newImage}: ${error}`;
-		if (continueOnError) { console.error(errorMessage); }
-		else { CORE.setFailed(errorMessage); }
+		handleError(errorMessage, targetProps.continueOnError);
 		return;
 	}
 	
-	if (forcePush) {
+	if (targetProps.forcePush) {
 		const ecr_client = new ECRClient();
 		const ecr_response = await ecr_client.send(new BatchDeleteImageCommand({
-			repositoryName: repository,
-			imageIds: [{ imageTag: tag }]
+			repositoryName: targetProps.repository,
+			imageIds: [{ imageTag: targetProps.tag }]
 		}));
 		if (ecr_response && ecr_response.failures && ecr_response.failures.length > 0) {
 			let error = false;
@@ -128,8 +211,7 @@ async function pushToECR(target) {
 	}
 	catch (error) {
 		const errorMessage = `push ${newImage}: ${error}`;
-		if (continueOnError) { console.error(errorMessage); }
-		else { CORE.setFailed(errorMessage); }
+		handleError(errorMessage, targetProps.continueOnError);
 		return;
 	}
   }
@@ -146,6 +228,11 @@ function execAsync(command) {
 			else { resolve(stdout); }
 		});
     });
+}
+
+function handleError(errorMessage, continueOnError) {
+    if (continueOnError) { console.error(errorMessage); }
+	else { CORE.setFailed(errorMessage); }
 }
 
 async function main() {

--- a/reservedTags.js
+++ b/reservedTags.js
@@ -1,0 +1,17 @@
+const CORE = require('@actions/core');
+
+async function readReservedTag(reserved_tag) {
+	switch (reserved_tag) {
+		case "app-version":
+			const app_version = CORE.getInput('app-version');
+			if (app_version)
+				return app_version;
+			else
+				throw `Action input 'app-version' is (${app_version})`;
+
+		default:
+			throw `Reserved tag ${reserved_tag} is not recognized. Make sure you only use reserved tags listed in the README.md`;
+	}
+}
+
+exports.readReservedTag = readReservedTag;


### PR DESCRIPTION
Goal: provide the action with a version (ex: v1.2.7) and the action will automatically tag the derived tags (v1.2, v1).

changes:
- new input 'app-version' for convenience
- new target property 'semantic-versioning' (in '.automation/deployment_envs.yaml')
- logic to create derived version tags according to semantic versioning
- update README.md accordingly

** Depends on PR (first review & merge): https://github.com/365Scores/push-to-ECR/pull/4